### PR TITLE
Fix tor show ip

### DIFF
--- a/src/core/requests/tor.py
+++ b/src/core/requests/tor.py
@@ -60,7 +60,7 @@ def do_check():
       new_ip = opener.open("http://icanhazip.com/").read()
       sys.stdout.write("[" + Fore.GREEN + " SUCCEED " + Style.RESET_ALL + "]\n")
       sys.stdout.flush()
-      success_msg = + "Your ip address appears to be " +  + new_ip
+      success_msg = "Your ip address appears to be " + new_ip
       sys.stdout.write(settings.print_success_msg(success_msg))
 
     except urllib2.URLError, err_msg:


### PR DESCRIPTION
Fix this error

```
[*] Testing privoxy proxy settings 127.0.0.1:8118... [ SUCCEED ]
Traceback (most recent call last):
  File "commix.py", line 743, in <module>
    main()
  File "commix.py", line 254, in main
    tor.do_check()
  File "/src/core/requests/tor.py", line 63, in do_check
    success_msg = + "Your ip address appears to be " + new_ip
TypeError: bad operand type for unary +: 'str'
```